### PR TITLE
passing data & hProps through to image nodes

### DIFF
--- a/lib/ast-to-react.js
+++ b/lib/ast-to-react.js
@@ -134,6 +134,10 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
         title: node.title || undefined,
         src: opts.transformImageUri ? opts.transformImageUri(node.url, node.children, node.title, node.alt) : node.url
       });
+
+      if (typeof node.data !== 'undefined' && typeof node.data.hProperties !== 'undefined') {
+        assignDefined(props, node.data.hProperties);
+      }
       break;
 
     case 'linkReference':

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-markdown",
   "description": "Renders Markdown as React components",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "keywords": [
     "markdown",
     "react",


### PR DESCRIPTION
# Notes
- In order to allow `data` and `hProperties` props to pass through to image nodes, we need to call `react-markdown`'s `assignDefined` function in the case of an image node.
- Bumping the version number so the app will know this repo has been updated.